### PR TITLE
ci: auto-release a versioned Windows installer on every push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+# Every push to master (including a merged PR) bumps the patch version,
+# builds the driver + Windows installer, tags the commit, and publishes a
+# GitHub Release with the installer attached.
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute next version
+        id: version
+        shell: bash
+        run: |
+          git fetch --tags --force
+          latest=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1)
+          if [ -z "$latest" ]; then
+            next="1.3.0"
+          else
+            major=$(echo "$latest" | cut -d. -f1)
+            minor=$(echo "$latest" | cut -d. -f2)
+            patch=$(echo "$latest" | cut -d. -f3)
+            next="$major.$minor.$((patch + 1))"
+          fi
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+          echo "tag=v$next" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${latest:-none}; next version: $next"
+
+      # AssemblyVersion is normally "1.2.*" (build/revision auto-generated from
+      # the compile timestamp) and AssemblyFileVersion is commented out, so the
+      # installer's version string (read from the built DLL's FileVersion via
+      # the .iss's GetStringFileInfo call) wouldn't match our release tag. Stamp
+      # both explicitly for this build only -- not committed back.
+      - name: Stamp assembly version
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}.0"
+          $path = "Properties/AssemblyInfo.cs"
+          $content = Get-Content $path -Raw
+          $content = $content -replace 'AssemblyVersion\("[^"]*"\)', "AssemblyVersion(`"$version`")"
+          $content = $content -replace '//\s*\[assembly: AssemblyFileVersion\("[^"]*"\)\]', "[assembly: AssemblyFileVersion(`"$version`")]"
+          Set-Content -Path $path -Value $content -NoNewline
+          Select-String -Path $path -Pattern "AssemblyVersion|AssemblyFileVersion"
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v2
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Restore NuGet packages
+        run: nuget restore VantagePro.csproj -PackagesDirectory packages
+
+      - name: Build driver
+        run: msbuild VantagePro.csproj /p:Configuration=Release /p:Platform=AnyCPU /p:RegisterForComInterop=false /verbosity:minimal
+
+      - name: Install Inno Setup
+        run: choco install innosetup -y --no-progress
+
+      - name: Build installer
+        shell: cmd
+        run: '"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" "VantagePro Setup.iss"'
+
+      - name: Locate installer
+        id: installer
+        shell: bash
+        # Construct the exact filename rather than globbing "Solution Items"/*.exe:
+        # that folder already has a hand-built "VantagePro Setup 1.2.exe" checked
+        # into git from a past release, and a glob could non-deterministically
+        # pick that stale file instead of the one ISCC just built this run.
+        run: |
+          exe="Solution Items/VantagePro Setup ${{ steps.version.outputs.version }}.0.exe"
+          if [ ! -f "$exe" ]; then
+            echo "Expected installer not found: $exe" >&2
+            ls -la "Solution Items"
+            exit 1
+          fi
+          echo "path=$exe" >> "$GITHUB_OUTPUT"
+          echo "Built installer: $exe"
+
+      - name: Tag release commit
+        run: |
+          git tag ${{ steps.version.outputs.tag }}
+          git push origin ${{ steps.version.outputs.tag }}
+
+      - name: Create GitHub release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ steps.version.outputs.tag }} `
+            "${{ steps.installer.outputs.path }}" `
+            --title "ASCOM VantagePro Driver ${{ steps.version.outputs.tag }}" `
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,11 @@ jobs:
         shell: bash
         run: |
           git fetch --tags --force
-          latest=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1)
+          # `|| true`: with no tags yet (the first-ever run), grep matches nothing
+          # and exits 1; combined with this shell's default `-o pipefail`, that
+          # would otherwise abort the whole step even though "no tags yet" is
+          # the expected, handled case below.
+          latest=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1) || true
           if [ -z "$latest" ]; then
             next="1.3.0"
           else

--- a/VantagePro Setup.iss
+++ b/VantagePro Setup.iss
@@ -23,11 +23,14 @@ DefaultDirName="{commoncf}\ASCOM\ObservingConditions"
 DisableDirPage=yes
 DisableProgramGroupPage=yes
 OutputDir="Solution Items"
-OutputBaseFilename="VantagePro Setup 1.2"
+OutputBaseFilename="VantagePro Setup {#asmbVersion}"
 Compression=lzma
 SolidCompression=yes
-; Put there by Platform if Driver Installer Support selected
-WizardImageFile="C:\Program Files (x86)\ASCOM\Platform 6 Developer Components\Installer Generator\Resources\WizardImage.bmp"
+; Vendored in-repo (Resources\ASCOM.bmp) rather than pointing at the ASCOM
+; Platform Developer Components' own copy of this file -- a CI build
+; wouldn't have the full Developer Components installed, only the
+; ASCOM.Platform NuGet package's reference assemblies.
+WizardImageFile="Resources\ASCOM.bmp"
 LicenseFile="Resources\LICENSE.GPL3"
 ; {cf}\ASCOM\Uninstall\ObservingConditions folder created by Platform, always
 UninstallFilesDir="{commoncf}\ASCOM\Uninstall\ObservingConditions\VantagePro"

--- a/VantagePro.csproj
+++ b/VantagePro.csproj
@@ -69,7 +69,7 @@
       CI runner that doesn't have ASCOM Platform installed. Private=False
       keeps these out of the build output (and installer), matching the
       pre-existing assumption that end users provide these via their own
-      ASCOM Platform install, same as before this HintPath was added -- if
+      ASCOM Platform install, same as before this HintPath was added. If
       the HintPath target is missing (e.g. a real dev machine that hasn't
       run nuget restore), MSBuild falls back to its normal GAC/search-path
       resolution, so this doesn't change behavior for a normal dev machine

--- a/VantagePro.csproj
+++ b/VantagePro.csproj
@@ -61,17 +61,55 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ASCOM.Astrometry, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
-    <Reference Include="ASCOM.Attributes, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
-    <Reference Include="ASCOM.Controls, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
-    <Reference Include="ASCOM.DeviceInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
-    <Reference Include="ASCOM.Exceptions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
-    <Reference Include="ASCOM.SettingsProvider, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
-    <Reference Include="ASCOM.Utilities, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
-    <Reference Include="ASCOM.Utilities.Video, Version=6.1.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL" />
+    <!--
+      HintPaths below point at the ASCOM.Platform NuGet package (restored via
+      `nuget restore VantagePro.csproj -PackagesDirectory packages`), which
+      bundles the same reference assemblies normally found in the GAC after
+      installing the real ASCOM Platform. This lets the project build on a
+      CI runner that doesn't have ASCOM Platform installed. Private=False
+      keeps these out of the build output (and installer), matching the
+      pre-existing assumption that end users provide these via their own
+      ASCOM Platform install, same as before this HintPath was added -- if
+      the HintPath target is missing (e.g. a real dev machine that hasn't
+      run nuget restore), MSBuild falls back to its normal GAC/search-path
+      resolution, so this doesn't change behavior for a normal dev machine
+      with ASCOM Platform installed.
+    -->
+    <Reference Include="ASCOM.Astrometry, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.Astrometry.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ASCOM.Attributes, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.Attributes.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ASCOM.Controls, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.Controls.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ASCOM.DeviceInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.DeviceInterfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ASCOM.Exceptions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.Exceptions.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ASCOM.SettingsProvider, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.SettingsProvider.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ASCOM.Utilities, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.Utilities.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ASCOM.Utilities.Video, Version=6.1.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
+      <HintPath>packages\ASCOM.Platform.6.5.2\lib\net40\ASCOM.Utilities.Video.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files (x86)\Common Files\ASCOM\ObservingConditions\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
+  <package id="ASCOM.Platform" version="6.5.2" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml`: on push to `master`, computes the next patch version from the latest `vX.Y.Z` tag (starting at v1.3.0 if none exist), stamps it into `AssemblyInfo.cs` for that build only, builds the driver, compiles the Inno Setup installer, tags the commit, and publishes a GitHub Release with the installer attached.
- Makes the build CI-capable without installing the full ASCOM Platform (its own installer isn't Inno/NSIS/MSI-based and has no documented silent-install path):
  - `packages.config` / `VantagePro.csproj` now reference the community-maintained `ASCOM.Platform` NuGet package (published specifically "for a build server or build agent") via `HintPath` for the 8 `ASCOM.*` GAC references, with `Private=False` so they're resolved at build time but not copied into the output/installer — same as before, where end users provide these via their own ASCOM Platform install. Falls back to normal GAC resolution if the HintPath target is absent, so a real dev machine with ASCOM Platform installed is unaffected.
  - Repoints Newtonsoft.Json's `HintPath` from a hardcoded local `Program Files (x86)\Common Files\ASCOM...` path (which never resolved in CI, and was fragile even locally) to the NuGet-restored package path.
  - `VantagePro Setup.iss`: `WizardImageFile` now points at the in-repo `Resources\ASCOM.bmp` instead of a file only present after installing the full ASCOM Platform Developer Components; `OutputBaseFilename` includes the version so each release's installer has a distinct, meaningful name.
- Two follow-up fixes folded in: the version-compute step no longer aborts under `pipefail` when `git tag -l | grep ...` finds no matching tags (expected on the very first run), and a double-hyphen in an XML comment that broke MSBuild's csproj parsing (`MSB4025`) is removed.

We've been running this successfully on our fork for a bit and figured it'd be useful upstream too. Opening as a draft since it's a build/release-infrastructure change and you may want to weigh in on the release/versioning approach before merging.

## Test plan
- [x] Verified passing on our fork's Actions runs (build, installer compile, tag, and release publish steps all succeeded across pushes)
- [ ] Maintainer review of the versioning/release approach (NuGet-sourced ASCOM.Platform references, tag-based patch bump)