### PR TITLE
Add WeatherLink Live JSON protocol option for IP mode

### DIFF
--- a/Driver.cs
+++ b/Driver.cs
@@ -159,13 +159,15 @@ namespace ASCOM.VantagePro
 
         protected virtual void Dispose(bool dispozing)
         {
-            if (dispozing)
-            {
-                // Clean up the tracelogger and util objects
-                tl.Enabled = false;
-                tl.Dispose();
-                tl = null;
-            }
+            // Deliberately not touching `tl` here. It's an alias for
+            // VantagePro.tl, a process-wide singleton shared by every Fetcher
+            // subclass and every ObservingConditions COM wrapper instance --
+            // ASCOM clients construct/dispose these routinely (Chooser
+            // previews, connect/disconnect cycles), and disposing + nulling
+            // the shared logger on the first one to go away used to silently
+            // kill tracing for the rest of the process, including for
+            // instances created afterwards (their constructor just re-reads
+            // the same, by-then-disposed, VantagePro.tl reference).
         }
 
         public void Dispose()

--- a/Fetcher.cs
+++ b/Fetcher.cs
@@ -52,9 +52,37 @@ namespace ASCOM.VantagePro
 
 		private readonly System.Threading.Timer timer = new System.Threading.Timer(new TimerCallback(OnTimer));
 
+		/// <summary>
+		/// Fetches once synchronously before scheduling the recurring async
+		/// timer. Without this, Connected=true returned control to the caller
+		/// immediately while the first fetch was still in flight on the
+		/// timer's thread pool thread -- a client reading any property in the
+		/// same breath as setting Connected (as MaximDL does) would hit
+		/// PropertyNotImplementedException on every single one, since
+		/// sensorData was still empty. This also matches Refresh()'s own
+		/// documented contract ("forces the driver to immediately query its
+		/// attached hardware"), which previously just restarted the async
+		/// timer without actually blocking for a fresh read.
+		/// </summary>
 		public void Start()
 		{
-			timer.Change(Convert.ToInt32(0), Timeout.Infinite);
+			string op = "Start";
+
+			try
+			{
+				#region trace
+				VantagePro.tl.LogMessage(op, "Calling lowerFetcher synchronously before starting the timer");
+				#endregion
+				lowerFetcher.FetchSensorData();
+			}
+			catch (Exception ex)
+			{
+				#region trace
+				VantagePro.tl.LogMessage(op, $"Caught: {ex.Message}");
+				#endregion
+			}
+
+			timer.Change(Convert.ToInt32(VantagePro.interval.TotalMilliseconds), Timeout.Infinite);
 		}
 
 		public void Stop()
@@ -149,7 +177,7 @@ namespace ASCOM.VantagePro
 					if (!sensorData.ContainsKey(key) || string.IsNullOrEmpty(sensorData[key]))
 					{
 						#region trace
-						VantagePro.tl.LogMessage(property, $"NullOrEmpty: sensorData[\"{property}\"]");
+						VantagePro.tl.LogMessage(property, $"NullOrEmpty: sensorData[\"{key}\"]");
 						#endregion
 						throw new PropertyNotImplementedException(property, false);
 					}

--- a/SetupDialogForm.cs
+++ b/SetupDialogForm.cs
@@ -17,6 +17,7 @@ namespace ASCOM.VantagePro
         private VantagePro vantagePro;
         private SerialPortFetcher serialPortFetcher;
         private SocketFetcher socketFetcher;
+        private WeatherLinkLiveFetcher weatherLinkLiveFetcher;
         private FileFetcher fileFetcher;
 
         public SetupDialogForm()
@@ -24,11 +25,13 @@ namespace ASCOM.VantagePro
             vantagePro = new VantagePro();
             serialPortFetcher = new SerialPortFetcher();
             socketFetcher = new SocketFetcher();
+            weatherLinkLiveFetcher = new WeatherLinkLiveFetcher();
             fileFetcher = new FileFetcher();
 
             vantagePro.ReadProfile();
             serialPortFetcher.ReadLowerProfile();
             socketFetcher.ReadLowerProfile();
+            weatherLinkLiveFetcher.ReadLowerProfile();
             fileFetcher.ReadLowerProfile();
 
             InitializeComponent();
@@ -52,9 +55,21 @@ namespace ASCOM.VantagePro
                 FileFetcher.DataFile = textBoxReportFile.Text;
             }
 
+            ushort ipPort;
+            try
+            {
+                ipPort = Convert.ToUInt16(textBoxIPPort.Text);
+            }
+            catch
+            {
+                ipPort = radioButtonIPProtocolJson.Checked ? WeatherLinkLiveFetcher.defaultPort : SocketFetcher.defaultPort;
+            }
             socketFetcher.Address = textBoxIPAddress.Text;
-            socketFetcher.Port = Convert.ToUInt16(textBoxIPPort.Text);
+            socketFetcher.Port = ipPort;
+            weatherLinkLiveFetcher.Address = textBoxIPAddress.Text;
+            weatherLinkLiveFetcher.Port = ipPort;
 
+            VantagePro.IPProtocol = radioButtonIPProtocolJson.Checked ? VantagePro.IPProtocolMode.Json : VantagePro.IPProtocolMode.Serial;
 
             if (radioButtonNone.Checked)
                 VantagePro.OperationalMode = VantagePro.OpMode.None;
@@ -71,6 +86,7 @@ namespace ASCOM.VantagePro
             vantagePro.WriteProfile();
             fileFetcher.WriteLowerProfile();
             socketFetcher.WriteLowerProfile();
+            weatherLinkLiveFetcher.WriteLowerProfile();
             serialPortFetcher.WriteLowerProfile();
 
             serialPortFetcher = null;
@@ -134,6 +150,17 @@ namespace ASCOM.VantagePro
             labelTracePath.Text = chkTrace.Checked ? VantagePro.traceLogFile : "";
             textBoxIPAddress.Text = socketFetcher.Address;
             textBoxInterval.Text = Convert.ToInt32(VantagePro.interval.TotalSeconds).ToString();
+
+            if (VantagePro.IPProtocol == VantagePro.IPProtocolMode.Json)
+            {
+                textBoxIPPort.Text = weatherLinkLiveFetcher.Port.ToString();
+                radioButtonIPProtocolJson.Checked = true;
+            }
+            else
+            {
+                textBoxIPPort.Text = socketFetcher.Port.ToString();
+                radioButtonIPProtocolSerial.Checked = true;
+            }
         }
 
         private void buttonChooser_Click(object sender, EventArgs e)
@@ -159,7 +186,7 @@ namespace ASCOM.VantagePro
             {
                 foreach (var control in new List<Control> { textBoxReportFile, buttonChooser })
                     control.Enabled = true;
-                foreach (var control in new List<Control> { comboBoxComPort, textBoxIPAddress, textBoxIPPort })
+                foreach (var control in new List<Control> { comboBoxComPort, textBoxIPAddress, textBoxIPPort, radioButtonIPProtocolSerial, radioButtonIPProtocolJson })
                     control.Enabled = false;
             }
         }
@@ -170,7 +197,7 @@ namespace ASCOM.VantagePro
             {
                 foreach (var control in new List<Control> { comboBoxComPort })
                     control.Enabled = true;
-                foreach (var control in new List<Control> { textBoxReportFile, buttonChooser, textBoxIPAddress, textBoxIPPort })
+                foreach (var control in new List<Control> { textBoxReportFile, buttonChooser, textBoxIPAddress, textBoxIPPort, radioButtonIPProtocolSerial, radioButtonIPProtocolJson })
                     control.Enabled = false;
             }
         }
@@ -179,7 +206,7 @@ namespace ASCOM.VantagePro
         {
             if ((sender as RadioButton).Checked)
             {
-                foreach (var control in new List<Control> { textBoxIPAddress, textBoxIPPort })
+                foreach (var control in new List<Control> { textBoxIPAddress, textBoxIPPort, radioButtonIPProtocolSerial, radioButtonIPProtocolJson })
                     control.Enabled = true;
                 foreach (var control in new List<Control> { comboBoxComPort, textBoxReportFile, buttonChooser })
                     control.Enabled = false;
@@ -188,8 +215,23 @@ namespace ASCOM.VantagePro
 
         private void radioButtonNone_CheckedChanged(object sender, EventArgs e)
         {
-            foreach (var control in new List<Control> { textBoxIPAddress, textBoxIPPort, comboBoxComPort, textBoxReportFile, buttonChooser })
+            foreach (var control in new List<Control> { textBoxIPAddress, textBoxIPPort, radioButtonIPProtocolSerial, radioButtonIPProtocolJson, comboBoxComPort, textBoxReportFile, buttonChooser })
                 control.Enabled = false;
+        }
+
+        private void radioButtonIPProtocolSerial_CheckedChanged(object sender, EventArgs e)
+        {
+            // Swap the displayed port to the other protocol's default, but
+            // only if the user hasn't already typed something of their own --
+            // don't clobber a deliberately-chosen non-default port.
+            if ((sender as RadioButton).Checked && textBoxIPPort.Text == WeatherLinkLiveFetcher.defaultPort.ToString())
+                textBoxIPPort.Text = SocketFetcher.defaultPort.ToString();
+        }
+
+        private void radioButtonIPProtocolJson_CheckedChanged(object sender, EventArgs e)
+        {
+            if ((sender as RadioButton).Checked && textBoxIPPort.Text == SocketFetcher.defaultPort.ToString())
+                textBoxIPPort.Text = WeatherLinkLiveFetcher.defaultPort.ToString();
         }
 
         private void chkTrace_CheckedChanged(object sender, EventArgs e)
@@ -217,6 +259,10 @@ namespace ASCOM.VantagePro
             else if (radioButtonSerialPort.Checked)
             {
                 serialPortFetcher.Test(comboBoxComPort.Text, ref result, ref resultColor);
+            }
+            else if (radioButtonIP.Checked && radioButtonIPProtocolJson.Checked)
+            {
+                weatherLinkLiveFetcher.Test(textBoxIPAddress.Text, textBoxIPPort.Text, ref result, ref resultColor);
             }
             else if (radioButtonIP.Checked)
             {

--- a/SetupDialogForm.designer.cs
+++ b/SetupDialogForm.designer.cs
@@ -54,6 +54,9 @@ namespace ASCOM.VantagePro
             this.labelRefreshInterval = new System.Windows.Forms.Label();
             this.textBoxInterval = new System.Windows.Forms.TextBox();
             this.label6 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.radioButtonIPProtocolSerial = new System.Windows.Forms.RadioButton();
+            this.radioButtonIPProtocolJson = new System.Windows.Forms.RadioButton();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.picASCOM)).BeginInit();
             this.groupBoxOpMode.SuspendLayout();
@@ -64,7 +67,7 @@ namespace ASCOM.VantagePro
             this.cmdOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cmdOK.CausesValidation = false;
             this.cmdOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.cmdOK.Location = new System.Drawing.Point(536, 193);
+            this.cmdOK.Location = new System.Drawing.Point(536, 219);
             this.cmdOK.Name = "cmdOK";
             this.cmdOK.Size = new System.Drawing.Size(59, 24);
             this.cmdOK.TabIndex = 0;
@@ -76,7 +79,7 @@ namespace ASCOM.VantagePro
             // 
             this.cmdCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cmdCancel.Location = new System.Drawing.Point(536, 229);
+            this.cmdCancel.Location = new System.Drawing.Point(536, 255);
             this.cmdCancel.Name = "cmdCancel";
             this.cmdCancel.Size = new System.Drawing.Size(59, 25);
             this.cmdCancel.TabIndex = 1;
@@ -121,7 +124,7 @@ namespace ASCOM.VantagePro
             // chkTrace
             // 
             this.chkTrace.AutoSize = true;
-            this.chkTrace.Location = new System.Drawing.Point(41, 234);
+            this.chkTrace.Location = new System.Drawing.Point(41, 260);
             this.chkTrace.Name = "chkTrace";
             this.chkTrace.Size = new System.Drawing.Size(69, 17);
             this.chkTrace.TabIndex = 6;
@@ -268,14 +271,14 @@ namespace ASCOM.VantagePro
             // 
             // labelTracePath
             // 
-            this.labelTracePath.Location = new System.Drawing.Point(116, 235);
+            this.labelTracePath.Location = new System.Drawing.Point(116, 261);
             this.labelTracePath.Name = "labelTracePath";
             this.labelTracePath.Size = new System.Drawing.Size(419, 16);
             this.labelTracePath.TabIndex = 19;
             // 
             // buttonTest
             // 
-            this.buttonTest.Location = new System.Drawing.Point(364, 195);
+            this.buttonTest.Location = new System.Drawing.Point(364, 221);
             this.buttonTest.Name = "buttonTest";
             this.buttonTest.Size = new System.Drawing.Size(114, 23);
             this.buttonTest.TabIndex = 20;
@@ -285,7 +288,7 @@ namespace ASCOM.VantagePro
             // 
             // labelRefreshInterval
             // 
-            this.labelRefreshInterval.Location = new System.Drawing.Point(148, 200);
+            this.labelRefreshInterval.Location = new System.Drawing.Point(148, 226);
             this.labelRefreshInterval.Name = "labelRefreshInterval";
             this.labelRefreshInterval.Size = new System.Drawing.Size(52, 13);
             this.labelRefreshInterval.TabIndex = 21;
@@ -294,7 +297,7 @@ namespace ASCOM.VantagePro
             // 
             // textBoxInterval
             // 
-            this.textBoxInterval.Location = new System.Drawing.Point(209, 196);
+            this.textBoxInterval.Location = new System.Drawing.Point(209, 222);
             this.textBoxInterval.Name = "textBoxInterval";
             this.textBoxInterval.Size = new System.Drawing.Size(29, 20);
             this.textBoxInterval.TabIndex = 22;
@@ -303,17 +306,53 @@ namespace ASCOM.VantagePro
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(242, 200);
+            this.label6.Location = new System.Drawing.Point(242, 226);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(47, 13);
             this.label6.TabIndex = 23;
             this.label6.Text = "seconds";
-            // 
+            //
+            // label7
+            //
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(145, 186);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(48, 13);
+            this.label7.TabIndex = 24;
+            this.label7.Text = "Protocol";
+            //
+            // radioButtonIPProtocolSerial
+            //
+            this.radioButtonIPProtocolSerial.AutoSize = true;
+            this.radioButtonIPProtocolSerial.Checked = true;
+            this.radioButtonIPProtocolSerial.Location = new System.Drawing.Point(209, 184);
+            this.radioButtonIPProtocolSerial.Name = "radioButtonIPProtocolSerial";
+            this.radioButtonIPProtocolSerial.Size = new System.Drawing.Size(96, 17);
+            this.radioButtonIPProtocolSerial.TabIndex = 25;
+            this.radioButtonIPProtocolSerial.TabStop = true;
+            this.radioButtonIPProtocolSerial.Text = "Legacy (22222)";
+            this.radioButtonIPProtocolSerial.UseVisualStyleBackColor = true;
+            this.radioButtonIPProtocolSerial.CheckedChanged += new System.EventHandler(this.radioButtonIPProtocolSerial_CheckedChanged);
+            //
+            // radioButtonIPProtocolJson
+            //
+            this.radioButtonIPProtocolJson.AutoSize = true;
+            this.radioButtonIPProtocolJson.Location = new System.Drawing.Point(340, 184);
+            this.radioButtonIPProtocolJson.Name = "radioButtonIPProtocolJson";
+            this.radioButtonIPProtocolJson.Size = new System.Drawing.Size(160, 17);
+            this.radioButtonIPProtocolJson.TabIndex = 26;
+            this.radioButtonIPProtocolJson.Text = "WeatherLink Live (JSON, 80)";
+            this.radioButtonIPProtocolJson.UseVisualStyleBackColor = true;
+            this.radioButtonIPProtocolJson.CheckedChanged += new System.EventHandler(this.radioButtonIPProtocolJson_CheckedChanged);
+            //
             // SetupDialogForm
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(607, 270);
+            this.ClientSize = new System.Drawing.Size(607, 296);
+            this.Controls.Add(this.radioButtonIPProtocolJson);
+            this.Controls.Add(this.radioButtonIPProtocolSerial);
+            this.Controls.Add(this.label7);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.textBoxInterval);
             this.Controls.Add(this.labelRefreshInterval);
@@ -377,5 +416,8 @@ namespace ASCOM.VantagePro
         private System.Windows.Forms.TextBox textBoxInterval;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.RadioButton radioButtonIPProtocolSerial;
+        private System.Windows.Forms.RadioButton radioButtonIPProtocolJson;
     }
 }

--- a/VantagePro.cs
+++ b/VantagePro.cs
@@ -21,6 +21,16 @@ namespace ASCOM.VantagePro
     public class VantagePro: WeatherStation
     {
         public enum OpMode { None, File, Serial, IP };
+
+        /// <summary>
+        /// Which wire protocol to speak when OperationalMode is OpMode.IP: the
+        /// legacy binary WeatherLinkIP protocol (wakeup/WRD/LOOP over a raw
+        /// socket, port 22222) that a standalone WeatherLinkIP data logger or
+        /// some consoles speak, or the modern WeatherLink Live local JSON API
+        /// (GET /v1/current_conditions, port 80) that the WeatherLink Live hub
+        /// speaks instead.
+        /// </summary>
+        public enum IPProtocolMode { Serial, Json };
         public static TimeSpan interval;
         public static Color colorGood = Color.Green;
         public static Color colorWarning = Color.Yellow;
@@ -29,6 +39,7 @@ namespace ASCOM.VantagePro
         private bool _initialized = false;
         private bool _connected = false;
         private static OpMode _opMode = OpMode.None;
+        private static IPProtocolMode _ipProtocol = IPProtocolMode.Serial;
 
         private static Fetcher fetcher;
 
@@ -61,9 +72,10 @@ namespace ASCOM.VantagePro
             }
         }
 
-        public static string Profile_OpMode   = "OperationMode";
-        public static string Profile_Tracing  = "Tracing";
-        public static string Profile_Interval = "IntervalSeconds";
+        public static string Profile_OpMode    = "OperationMode";
+        public static string Profile_Tracing   = "Tracing";
+        public static string Profile_Interval  = "IntervalSeconds";
+        public static string Profile_IPProtocol = "IPProtocol";
 
         public static VantagePro Instance
         {
@@ -107,11 +119,38 @@ namespace ASCOM.VantagePro
                         fetcher = new SerialPortFetcher();
                         break;
                     case OpMode.IP:
-                        fetcher = new SocketFetcher();
+                        fetcher = NewIPFetcher();
                         break;
 
                 }
             }
+        }
+
+        /// <summary>
+        /// Which wire protocol OpMode.IP should speak. Setting this when the
+        /// operational mode is already IP swaps the live fetcher immediately
+        /// (mirrors OperationalMode's own setter), so flipping this in the
+        /// Setup dialog and clicking "Test configuration" reflects the choice
+        /// right away without requiring a full reconnect.
+        /// </summary>
+        public static IPProtocolMode IPProtocol
+        {
+            get
+            {
+                return _ipProtocol;
+            }
+
+            set
+            {
+                _ipProtocol = value;
+                if (_opMode == OpMode.IP)
+                    fetcher = NewIPFetcher();
+            }
+        }
+
+        private static Fetcher NewIPFetcher()
+        {
+            return (_ipProtocol == IPProtocolMode.Json) ? (Fetcher)new WeatherLinkLiveFetcher() : new SocketFetcher();
         }
 
         public bool Tracing {
@@ -171,7 +210,7 @@ namespace ASCOM.VantagePro
                     break;
 
                 case OpMode.IP:
-                    fetcher = new SocketFetcher();
+                    fetcher = NewIPFetcher();
                     break;
             }
 
@@ -307,6 +346,9 @@ namespace ASCOM.VantagePro
         {
             using (Profile driverProfile = new Profile() { DeviceType = "ObservingConditions" })
             {
+                Enum.TryParse<IPProtocolMode>(driverProfile.GetValue(DriverId, Profile_IPProtocol, string.Empty, IPProtocolMode.Serial.ToString()), out IPProtocolMode ipProtocol);
+                _ipProtocol = ipProtocol;
+
                 Enum.TryParse<OpMode>(driverProfile.GetValue(DriverId, Profile_OpMode, string.Empty, OpMode.None.ToString()), out OpMode mode);
                 OperationalMode = mode;
 
@@ -323,6 +365,7 @@ namespace ASCOM.VantagePro
             using (Profile driverProfile = new Profile() { DeviceType = "ObservingConditions" })
             {
                 driverProfile.WriteValue(DriverId, Profile_OpMode, OperationalMode.ToString());
+                driverProfile.WriteValue(DriverId, Profile_IPProtocol, IPProtocol.ToString());
                 driverProfile.WriteValue(DriverId, Profile_Tracing, Tracing.ToString());
                 driverProfile.WriteValue(DriverId, Profile_Interval, interval.TotalSeconds.ToString());
                 if (fetcher != null)
@@ -610,6 +653,8 @@ namespace ASCOM.VantagePro
         {
             get
             {
+                if (VantagePro.OperationalMode == OpMode.IP && VantagePro.IPProtocol == IPProtocolMode.Json)
+                    return WeatherStationInputMethod.WeatherLink_LiveJson;
                 return opMode2InputMethod[VantagePro.OperationalMode];
             }
 

--- a/VantagePro.csproj
+++ b/VantagePro.csproj
@@ -111,6 +111,7 @@
     <Compile Include="VantagePro.cs" />
     <Compile Include="Weather.cs" />
     <Compile Include="WeatherLinkLiveFetcher.cs" />
+    <Compile Include="WeatherLinkLiveParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/VantagePro.csproj
+++ b/VantagePro.csproj
@@ -110,6 +110,7 @@
     <Compile Include="SocketFetcher.cs" />
     <Compile Include="VantagePro.cs" />
     <Compile Include="Weather.cs" />
+    <Compile Include="WeatherLinkLiveFetcher.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/Weather.cs
+++ b/Weather.cs
@@ -16,6 +16,7 @@ namespace Weather
             WeatherLink_HtmlReport,
             WeatherLink_Serial,
             WeatherLink_IP,
+            WeatherLink_LiveJson,
             TessW,
         };
 

--- a/WeatherLinkLiveFetcher.cs
+++ b/WeatherLinkLiveFetcher.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Net;
+using ASCOM.Utilities;
+using Newtonsoft.Json.Linq;
+
+namespace ASCOM.VantagePro
+{
+    /// <summary>
+    /// Speaks the modern WeatherLink Live local API instead of the legacy
+    /// binary WeatherLinkIP protocol: a plain HTTP GET of
+    /// /v1/current_conditions (port 80 on a real WeatherLink Live hub),
+    /// returning JSON rather than a wakeup/WRD/LOOP binary exchange.
+    ///
+    /// Shares its IP address/port profile keys with <see cref="SocketFetcher"/>
+    /// since both are just "the WeatherLinkIP mode" (VantagePro.OpMode.IP) with
+    /// a different wire protocol selected via VantagePro.IPProtocol -- same
+    /// physical host:port, same Setup dialog fields.
+    /// </summary>
+    public class WeatherLinkLiveFetcher : Fetcher
+    {
+        public const ushort defaultPort = 80;
+
+        private static readonly Util util = new Util();
+
+        private string _stationModel = "Unknown";
+        private string _stationName = "Unknown";
+
+        public string Address { get; set; }
+        public UInt16 Port { get; set; } = defaultPort;
+
+        public WeatherLinkLiveFetcher()
+        {
+            ReadLowerProfile();
+            lowerFetcher = this;
+        }
+
+        /// <summary>
+        /// Read the device configuration from the ASCOM Profile store. Reuses
+        /// SocketFetcher's profile keys: this is the same "IP" operational
+        /// mode, just a different protocol.
+        /// </summary>
+        public override void ReadLowerProfile()
+        {
+            using (Profile driverProfile = new Profile() { DeviceType = "ObservingConditions" })
+            {
+                string op = "ReadLowerProfile";
+                Address = driverProfile.GetValue(DriverId, SocketFetcher.Profile_IPAddress, string.Empty, "");
+                Port = Convert.ToUInt16(driverProfile.GetValue(DriverId, SocketFetcher.Profile_IPPort, string.Empty, defaultPort.ToString()));
+                #region trace
+                VantagePro.LogMessage(op, $"Address: '{Address}', Port: '{Port}'");
+                #endregion
+            }
+        }
+
+        public override void WriteLowerProfile()
+        {
+            using (Profile driverProfile = new Profile() { DeviceType = "ObservingConditions" })
+            {
+                string op = "WriteLowerProfile";
+
+                driverProfile.WriteValue(DriverId, SocketFetcher.Profile_IPAddress, Address);
+                driverProfile.WriteValue(DriverId, SocketFetcher.Profile_IPPort, Port.ToString());
+                #region trace
+                VantagePro.LogMessage(op, $"Address: '{Address}', Port: '{Port}'");
+                #endregion
+            }
+        }
+
+        public string Source
+        {
+            get
+            {
+                return $"[{Address}:{Port}]";
+            }
+        }
+
+        private string Url
+        {
+            get
+            {
+                return $"http://{Address}:{Port}/v1/current_conditions";
+            }
+        }
+
+        /// <summary>
+        /// Fetches and parses one /v1/current_conditions response.
+        /// Returns null (and logs why) on any network failure, malformed
+        /// JSON, or a well-formed "no data" response -- callers treat that
+        /// exactly like a WeatherLinkIP LOOP request that got no ACK: leave
+        /// LastRead untouched so TimeSinceLastUpdate reflects the outage.
+        /// </summary>
+        private JObject FetchCurrentConditions(out string error)
+        {
+            string op = "WeatherLinkLive.Fetch";
+            error = null;
+
+            if (string.IsNullOrWhiteSpace(Address))
+            {
+                error = "empty address";
+                return null;
+            }
+
+            string body;
+            try
+            {
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(Url);
+                request.Method = "GET";
+                request.Timeout = 5000;
+                request.ReadWriteTimeout = 5000;
+
+                using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+                using (Stream stream = response.GetResponseStream())
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    body = reader.ReadToEnd();
+                }
+            }
+            catch (Exception ex)
+            {
+                error = $"{ex.GetType().Name}: {ex.Message}";
+                #region trace
+                VantagePro.LogMessage(op, $"{Source}: GET {Url} failed: {error}");
+                #endregion
+                return null;
+            }
+
+            JObject root;
+            try
+            {
+                root = JObject.Parse(body);
+            }
+            catch (Exception ex)
+            {
+                error = $"malformed JSON: {ex.Message}";
+                #region trace
+                VantagePro.LogMessage(op, $"{Source}: {error}. Body: {body}");
+                #endregion
+                return null;
+            }
+
+            if (!(root["data"] is JObject data))
+            {
+                error = (string)root["error"] ?? "no \"data\" in response (station reports no current conditions)";
+                #region trace
+                VantagePro.LogMessage(op, $"{Source}: {error}");
+                #endregion
+                return null;
+            }
+
+            #region trace
+            VantagePro.LogMessage(op, $"{Source}: Got conditions, did: {(string)data["did"]}, ts: {(string)data["ts"]}");
+            #endregion
+            return data;
+        }
+
+        private static double? AsDouble(JToken token)
+        {
+            return (token == null || token.Type == JTokenType.Null) ? (double?)null : token.Value<double>();
+        }
+
+        public override void FetchSensorData()
+        {
+            string op = "FetchSensorData";
+
+            JObject data = FetchCurrentConditions(out string error);
+            if (data == null)
+            {
+                #region trace
+                VantagePro.LogMessage(op, $"{Source}: {error}");
+                #endregion
+                return;
+            }
+
+            if (!(data["conditions"] is JArray conditions))
+            {
+                #region trace
+                VantagePro.LogMessage(op, $"{Source}: response has no \"conditions\" array");
+                #endregion
+                return;
+            }
+
+            JObject iss = null, bar = null;
+            foreach (JToken cond in conditions)
+            {
+                int? type = (int?)cond["data_structure_type"];
+                if (type == 1 && iss == null)
+                    iss = cond as JObject;
+                else if (type == 3 && bar == null)
+                    bar = cond as JObject;
+            }
+
+            if (iss == null)
+            {
+                #region trace
+                VantagePro.LogMessage(op, $"{Source}: no data_structure_type=1 (ISS) block in conditions -- nothing to parse");
+                #endregion
+                return;
+            }
+
+            lock (sensorDataLock)
+            {
+                double? tempF = AsDouble(iss["temp"]);
+                if (tempF.HasValue)
+                {
+                    sensorData["outsideTemp"] = util.ConvertUnits(tempF.Value, Units.degreesFahrenheit, Units.degreesCelsius).ToString();
+                    #region trace
+                    VantagePro.tl.LogMessage("outsideTemp", $"Fahrenheit: {tempF} -> sensorData[\"outsideTemp\"]: {sensorData["outsideTemp"]} (Celsius)");
+                    #endregion
+                }
+
+                double? hum = AsDouble(iss["hum"]);
+                if (hum.HasValue)
+                    sensorData["outsideHumidity"] = hum.Value.ToString();
+
+                double? dewF = AsDouble(iss["dew_point"]);
+                if (dewF.HasValue)
+                    sensorData["outsideDewPt"] = util.ConvertUnits(dewF.Value, Units.degreesFahrenheit, Units.degreesCelsius).ToString();
+
+                double? windAvgMph = AsDouble(iss["wind_speed_avg_last_2_min"]);
+                if (windAvgMph.HasValue)
+                {
+                    sensorData["windSpeed"] = util.ConvertUnits(windAvgMph.Value, Units.milesPerHour, Units.metresPerSecond).ToString();
+                    #region trace
+                    VantagePro.tl.LogMessage("windSpeed", $"mph: {windAvgMph} -> sensorData[\"windSpeed\"]: {sensorData["windSpeed"]} (m/s)");
+                    #endregion
+                }
+
+                double? windDir = AsDouble(iss["wind_dir_scalar_avg_last_2_min"]);
+                if (windDir.HasValue)
+                    sensorData["windDir"] = windDir.Value.ToString();
+
+                // "Peak 3 second wind gust over the last 2 minutes" per the
+                // ASCOM IObservingConditions contract has no exact analog in
+                // this API; wind_speed_hi_last_10_min (the highest recent
+                // sample) is the closest match, same as the legacy binary
+                // path's use of the LOOP packet's "10-min high" field.
+                double? windGustMph = AsDouble(iss["wind_speed_hi_last_10_min"]);
+                if (windGustMph.HasValue)
+                {
+                    sensorData["windGust"] = util.ConvertUnits(windGustMph.Value, Units.milesPerHour, Units.metresPerSecond).ToString();
+                    #region trace
+                    VantagePro.tl.LogMessage("windGust", $"mph: {windGustMph} -> sensorData[\"windGust\"]: {sensorData["windGust"]}");
+                    #endregion
+                }
+
+                // Already a physical rain rate (in/hr), unlike the legacy
+                // binary path which stores a raw, unconverted click count.
+                double? rainRate = AsDouble(iss["rain_rate_last"]);
+                if (rainRate.HasValue)
+                    sensorData["rainRate"] = rainRate.Value.ToString();
+
+                if (bar != null)
+                {
+                    double? barInHg = AsDouble(bar["bar_sea_level"]);
+                    if (barInHg.HasValue)
+                        sensorData["barometer"] = util.ConvertUnits(barInHg.Value, Units.inHg, Units.hPa).ToString();
+                }
+
+                _stationName = (string)data["did"] ?? _stationName;
+            }
+
+            LastRead = DateTime.Now;
+            #region trace
+            VantagePro.LogMessage(op, $"{Source}: End");
+            #endregion
+        }
+
+        public override string StationModel
+        {
+            get
+            {
+                return _stationModel;
+            }
+
+            set
+            {
+                _stationModel = value;
+            }
+        }
+
+        public override string StationName
+        {
+            get
+            {
+                return _stationName;
+            }
+
+            set
+            {
+                _stationName = value;
+            }
+        }
+
+        public override VantagePro.DataSourceClass DataSource
+        {
+            get
+            {
+                return new VantagePro.DataSourceClass
+                {
+                    Type = "http",
+                    Details = Url,
+                };
+            }
+        }
+
+        public void Test(string address, string port, ref string result, ref Color color)
+        {
+            string op = "WeatherLinkLive.Test";
+
+            #region trace
+            VantagePro.LogMessage(op, "Start");
+            #endregion
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                result = "Empty IP address";
+                color = VantagePro.colorError;
+                return;
+            }
+            Address = address;
+
+            if (string.IsNullOrWhiteSpace(port))
+            {
+                Port = defaultPort;
+            }
+            else
+            {
+                try
+                {
+                    Port = Convert.ToUInt16(port);
+                }
+                catch
+                {
+                    Port = defaultPort;
+                }
+            }
+
+            JObject data = FetchCurrentConditions(out string error);
+            if (data != null)
+            {
+                string did = (string)data["did"];
+                result = $"Found a WeatherLink Live station (did: {did}) at {Url}.";
+                color = VantagePro.colorGood;
+                #region trace
+                VantagePro.LogMessage(op, result);
+                #endregion
+            }
+            else
+            {
+                result = $"Could not get current conditions from {Url}: {error}";
+                color = VantagePro.colorError;
+                #region trace
+                VantagePro.LogMessage(op, result);
+                #endregion
+            }
+            #region trace
+            VantagePro.LogMessage(op, "Done");
+            #endregion
+        }
+    }
+}

--- a/WeatherLinkLiveFetcher.cs
+++ b/WeatherLinkLiveFetcher.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Drawing;
-using System.IO;
-using System.Net;
 using ASCOM.Utilities;
-using Newtonsoft.Json.Linq;
 
 namespace ASCOM.VantagePro
 {
@@ -17,12 +14,16 @@ namespace ASCOM.VantagePro
     /// since both are just "the WeatherLinkIP mode" (VantagePro.OpMode.IP) with
     /// a different wire protocol selected via VantagePro.IPProtocol -- same
     /// physical host:port, same Setup dialog fields.
+    ///
+    /// The actual fetch/parse/unit-conversion logic lives in
+    /// WeatherLinkLiveParser (no ASCOM.Utilities dependency, so it can also
+    /// run standalone under wll-cli); this class is the thin ASCOM-side
+    /// wrapper that calls it and copies results into sensorData, with
+    /// tracing and Profile-backed settings persistence on top.
     /// </summary>
     public class WeatherLinkLiveFetcher : Fetcher
     {
         public const ushort defaultPort = 80;
-
-        private static readonly Util util = new Util();
 
         private string _stationModel = "Unknown";
         private string _stationName = "Unknown";
@@ -84,181 +85,78 @@ namespace ASCOM.VantagePro
             }
         }
 
-        /// <summary>
-        /// Fetches and parses one /v1/current_conditions response.
-        /// Returns null (and logs why) on any network failure, malformed
-        /// JSON, or a well-formed "no data" response -- callers treat that
-        /// exactly like a WeatherLinkIP LOOP request that got no ACK: leave
-        /// LastRead untouched so TimeSinceLastUpdate reflects the outage.
-        /// </summary>
-        private JObject FetchCurrentConditions(out string error)
-        {
-            string op = "WeatherLinkLive.Fetch";
-            error = null;
-
-            if (string.IsNullOrWhiteSpace(Address))
-            {
-                error = "empty address";
-                return null;
-            }
-
-            string body;
-            try
-            {
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(Url);
-                request.Method = "GET";
-                request.Timeout = 5000;
-                request.ReadWriteTimeout = 5000;
-
-                using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
-                using (Stream stream = response.GetResponseStream())
-                using (StreamReader reader = new StreamReader(stream))
-                {
-                    body = reader.ReadToEnd();
-                }
-            }
-            catch (Exception ex)
-            {
-                error = $"{ex.GetType().Name}: {ex.Message}";
-                #region trace
-                VantagePro.LogMessage(op, $"{Source}: GET {Url} failed: {error}");
-                #endregion
-                return null;
-            }
-
-            JObject root;
-            try
-            {
-                root = JObject.Parse(body);
-            }
-            catch (Exception ex)
-            {
-                error = $"malformed JSON: {ex.Message}";
-                #region trace
-                VantagePro.LogMessage(op, $"{Source}: {error}. Body: {body}");
-                #endregion
-                return null;
-            }
-
-            if (!(root["data"] is JObject data))
-            {
-                error = (string)root["error"] ?? "no \"data\" in response (station reports no current conditions)";
-                #region trace
-                VantagePro.LogMessage(op, $"{Source}: {error}");
-                #endregion
-                return null;
-            }
-
-            #region trace
-            VantagePro.LogMessage(op, $"{Source}: Got conditions, did: {(string)data["did"]}, ts: {(string)data["ts"]}");
-            #endregion
-            return data;
-        }
-
-        private static double? AsDouble(JToken token)
-        {
-            return (token == null || token.Type == JTokenType.Null) ? (double?)null : token.Value<double>();
-        }
-
         public override void FetchSensorData()
         {
             string op = "FetchSensorData";
 
-            JObject data = FetchCurrentConditions(out string error);
-            if (data == null)
+            if (string.IsNullOrWhiteSpace(Address))
+            {
+                #region trace
+                VantagePro.LogMessage(op, "empty address");
+                #endregion
+                return;
+            }
+
+            string json = WeatherLinkLiveParser.FetchJson(Address, Port, 5000, out string error);
+            if (json == null)
+            {
+                #region trace
+                VantagePro.LogMessage(op, $"{Source}: GET {Url} failed: {error}");
+                #endregion
+                return;
+            }
+
+            WeatherLinkLiveConditions cond = WeatherLinkLiveParser.Parse(json, out error);
+            if (cond == null)
             {
                 #region trace
                 VantagePro.LogMessage(op, $"{Source}: {error}");
-                #endregion
-                return;
-            }
-
-            if (!(data["conditions"] is JArray conditions))
-            {
-                #region trace
-                VantagePro.LogMessage(op, $"{Source}: response has no \"conditions\" array");
-                #endregion
-                return;
-            }
-
-            JObject iss = null, bar = null;
-            foreach (JToken cond in conditions)
-            {
-                int? type = (int?)cond["data_structure_type"];
-                if (type == 1 && iss == null)
-                    iss = cond as JObject;
-                else if (type == 3 && bar == null)
-                    bar = cond as JObject;
-            }
-
-            if (iss == null)
-            {
-                #region trace
-                VantagePro.LogMessage(op, $"{Source}: no data_structure_type=1 (ISS) block in conditions -- nothing to parse");
                 #endregion
                 return;
             }
 
             lock (sensorDataLock)
             {
-                double? tempF = AsDouble(iss["temp"]);
-                if (tempF.HasValue)
+                if (cond.TempC.HasValue)
                 {
-                    sensorData["outsideTemp"] = util.ConvertUnits(tempF.Value, Units.degreesFahrenheit, Units.degreesCelsius).ToString();
+                    sensorData["outsideTemp"] = cond.TempC.Value.ToString();
                     #region trace
-                    VantagePro.tl.LogMessage("outsideTemp", $"Fahrenheit: {tempF} -> sensorData[\"outsideTemp\"]: {sensorData["outsideTemp"]} (Celsius)");
+                    VantagePro.tl.LogMessage("outsideTemp", $"sensorData[\"outsideTemp\"]: {sensorData["outsideTemp"]} (Celsius)");
                     #endregion
                 }
 
-                double? hum = AsDouble(iss["hum"]);
-                if (hum.HasValue)
-                    sensorData["outsideHumidity"] = hum.Value.ToString();
+                if (cond.HumidityPct.HasValue)
+                    sensorData["outsideHumidity"] = cond.HumidityPct.Value.ToString();
 
-                double? dewF = AsDouble(iss["dew_point"]);
-                if (dewF.HasValue)
-                    sensorData["outsideDewPt"] = util.ConvertUnits(dewF.Value, Units.degreesFahrenheit, Units.degreesCelsius).ToString();
+                if (cond.DewPointC.HasValue)
+                    sensorData["outsideDewPt"] = cond.DewPointC.Value.ToString();
 
-                double? windAvgMph = AsDouble(iss["wind_speed_avg_last_2_min"]);
-                if (windAvgMph.HasValue)
+                if (cond.WindSpeedMps.HasValue)
                 {
-                    sensorData["windSpeed"] = util.ConvertUnits(windAvgMph.Value, Units.milesPerHour, Units.metresPerSecond).ToString();
+                    sensorData["windSpeed"] = cond.WindSpeedMps.Value.ToString();
                     #region trace
-                    VantagePro.tl.LogMessage("windSpeed", $"mph: {windAvgMph} -> sensorData[\"windSpeed\"]: {sensorData["windSpeed"]} (m/s)");
+                    VantagePro.tl.LogMessage("windSpeed", $"sensorData[\"windSpeed\"]: {sensorData["windSpeed"]} (m/s)");
                     #endregion
                 }
 
-                double? windDir = AsDouble(iss["wind_dir_scalar_avg_last_2_min"]);
-                if (windDir.HasValue)
-                    sensorData["windDir"] = windDir.Value.ToString();
+                if (cond.WindDirDeg.HasValue)
+                    sensorData["windDir"] = cond.WindDirDeg.Value.ToString();
 
-                // "Peak 3 second wind gust over the last 2 minutes" per the
-                // ASCOM IObservingConditions contract has no exact analog in
-                // this API; wind_speed_hi_last_10_min (the highest recent
-                // sample) is the closest match, same as the legacy binary
-                // path's use of the LOOP packet's "10-min high" field.
-                double? windGustMph = AsDouble(iss["wind_speed_hi_last_10_min"]);
-                if (windGustMph.HasValue)
+                if (cond.WindGustMps.HasValue)
                 {
-                    sensorData["windGust"] = util.ConvertUnits(windGustMph.Value, Units.milesPerHour, Units.metresPerSecond).ToString();
+                    sensorData["windGust"] = cond.WindGustMps.Value.ToString();
                     #region trace
-                    VantagePro.tl.LogMessage("windGust", $"mph: {windGustMph} -> sensorData[\"windGust\"]: {sensorData["windGust"]}");
+                    VantagePro.tl.LogMessage("windGust", $"sensorData[\"windGust\"]: {sensorData["windGust"]}");
                     #endregion
                 }
 
-                // Already a physical rain rate (in/hr), unlike the legacy
-                // binary path which stores a raw, unconverted click count.
-                double? rainRate = AsDouble(iss["rain_rate_last"]);
-                if (rainRate.HasValue)
-                    sensorData["rainRate"] = rainRate.Value.ToString();
+                if (cond.RainRateInPerHr.HasValue)
+                    sensorData["rainRate"] = cond.RainRateInPerHr.Value.ToString();
 
-                if (bar != null)
-                {
-                    double? barInHg = AsDouble(bar["bar_sea_level"]);
-                    if (barInHg.HasValue)
-                        sensorData["barometer"] = util.ConvertUnits(barInHg.Value, Units.inHg, Units.hPa).ToString();
-                }
+                if (cond.BarometerHPa.HasValue)
+                    sensorData["barometer"] = cond.BarometerHPa.Value.ToString();
 
-                _stationName = (string)data["did"] ?? _stationName;
+                _stationName = cond.StationId ?? _stationName;
             }
 
             LastRead = DateTime.Now;
@@ -336,11 +234,12 @@ namespace ASCOM.VantagePro
                 }
             }
 
-            JObject data = FetchCurrentConditions(out string error);
-            if (data != null)
+            string json = WeatherLinkLiveParser.FetchJson(Address, Port, 5000, out string error);
+            WeatherLinkLiveConditions cond = json == null ? null : WeatherLinkLiveParser.Parse(json, out error);
+
+            if (cond != null)
             {
-                string did = (string)data["did"];
-                result = $"Found a WeatherLink Live station (did: {did}) at {Url}.";
+                result = $"Found a WeatherLink Live station (did: {cond.StationId}) at {Url}.";
                 color = VantagePro.colorGood;
                 #region trace
                 VantagePro.LogMessage(op, result);

--- a/WeatherLinkLiveParser.cs
+++ b/WeatherLinkLiveParser.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Net;
+using Newtonsoft.Json.Linq;
+
+namespace ASCOM.VantagePro
+{
+    /// <summary>
+    /// Plain values parsed out of one /v1/current_conditions response, in the
+    /// same units Fetcher's properties expect (Celsius, m/s, hPa, in/hr).
+    /// </summary>
+    public class WeatherLinkLiveConditions
+    {
+        public string StationId;
+        public double? TempC;
+        public double? HumidityPct;
+        public double? DewPointC;
+        public double? WindSpeedMps;
+        public double? WindDirDeg;
+        public double? WindGustMps;
+        public double? RainRateInPerHr;
+        public double? BarometerHPa;
+    }
+
+    /// <summary>
+    /// Fetch + parse logic for the WeatherLink Live local API
+    /// (GET /v1/current_conditions), deliberately free of any ASCOM.Utilities
+    /// dependency (Profile/Util/TraceLogger all pull in Microsoft.VisualBasic
+    /// at runtime, which real .NET Framework/Windows has but plain Mono does
+    /// not -- Debian's Mono package ships no runtime implementation of it at
+    /// all). That split lets this class run standalone (e.g. from wll-cli,
+    /// a command-line harness usable on Linux/Mono for diagnosing the wire
+    /// protocol without the full ASCOM Platform installed) while
+    /// WeatherLinkLiveFetcher stays a thin wrapper that calls this and copies
+    /// results into the ASCOM-side sensorData dictionary, with its own
+    /// tracing on top.
+    /// </summary>
+    public static class WeatherLinkLiveParser
+    {
+        public const double HpaPerInHg = 33.8639;
+        public const double MpsPerMph = 0.44704;
+
+        public static double FahrenheitToCelsius(double f)
+        {
+            return (f - 32.0) * 5.0 / 9.0;
+        }
+
+        /// <summary>GET http://address:port/v1/current_conditions. Returns null (and sets error) on any failure.</summary>
+        public static string FetchJson(string address, int port, int timeoutMs, out string error)
+        {
+            error = null;
+            string url = $"http://{address}:{port}/v1/current_conditions";
+
+            try
+            {
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+                request.Method = "GET";
+                request.Timeout = timeoutMs;
+                request.ReadWriteTimeout = timeoutMs;
+
+                using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+                using (Stream stream = response.GetResponseStream())
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+            catch (Exception ex)
+            {
+                error = $"{ex.GetType().Name}: {ex.Message}";
+                return null;
+            }
+        }
+
+        private static double? AsDouble(JToken token)
+        {
+            return (token == null || token.Type == JTokenType.Null) ? (double?)null : token.Value<double>();
+        }
+
+        /// <summary>
+        /// Parses one /v1/current_conditions response body. Returns null
+        /// (and sets error) on malformed JSON, a well-formed "no data"
+        /// response, or a response with no data_structure_type=1 (ISS) block
+        /// -- the only field set this driver actually reads.
+        /// </summary>
+        public static WeatherLinkLiveConditions Parse(string json, out string error)
+        {
+            error = null;
+
+            JObject root;
+            try
+            {
+                root = JObject.Parse(json);
+            }
+            catch (Exception ex)
+            {
+                error = $"malformed JSON: {ex.Message}";
+                return null;
+            }
+
+            if (!(root["data"] is JObject data))
+            {
+                error = (string)root["error"] ?? "no \"data\" in response (station reports no current conditions)";
+                return null;
+            }
+
+            if (!(data["conditions"] is JArray conditions))
+            {
+                error = "response has no \"conditions\" array";
+                return null;
+            }
+
+            JObject iss = null, bar = null;
+            foreach (JToken cond in conditions)
+            {
+                int? type = (int?)cond["data_structure_type"];
+                if (type == 1 && iss == null)
+                    iss = cond as JObject;
+                else if (type == 3 && bar == null)
+                    bar = cond as JObject;
+            }
+
+            if (iss == null)
+            {
+                error = "no data_structure_type=1 (ISS) block in conditions -- nothing to parse";
+                return null;
+            }
+
+            var result = new WeatherLinkLiveConditions { StationId = (string)data["did"] };
+
+            double? tempF = AsDouble(iss["temp"]);
+            if (tempF.HasValue)
+                result.TempC = FahrenheitToCelsius(tempF.Value);
+
+            result.HumidityPct = AsDouble(iss["hum"]);
+
+            double? dewF = AsDouble(iss["dew_point"]);
+            if (dewF.HasValue)
+                result.DewPointC = FahrenheitToCelsius(dewF.Value);
+
+            double? windAvgMph = AsDouble(iss["wind_speed_avg_last_2_min"]);
+            if (windAvgMph.HasValue)
+                result.WindSpeedMps = windAvgMph.Value * MpsPerMph;
+
+            result.WindDirDeg = AsDouble(iss["wind_dir_scalar_avg_last_2_min"]);
+
+            // See WeatherLinkLiveFetcher for why wind_speed_hi_last_10_min is
+            // used as the closest analog to "gust" this API offers.
+            double? windGustMph = AsDouble(iss["wind_speed_hi_last_10_min"]);
+            if (windGustMph.HasValue)
+                result.WindGustMps = windGustMph.Value * MpsPerMph;
+
+            result.RainRateInPerHr = AsDouble(iss["rain_rate_last"]);
+
+            if (bar != null)
+            {
+                double? barInHg = AsDouble(bar["bar_sea_level"]);
+                if (barInHg.HasValue)
+                    result.BarometerHPa = barInHg.Value * HpaPerInHg;
+            }
+
+            return result;
+        }
+    }
+}

--- a/wll-cli/Program.cs
+++ b/wll-cli/Program.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading;
+using ASCOM.VantagePro;
+
+namespace ASCOM.VantagePro.WllCli
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if (args.Length < 1 || args[0] == "-h" || args[0] == "--help")
+            {
+                Console.Error.WriteLine("usage: wll-cli <host> [port=80] [--raw] [--loop] [--interval seconds=10]");
+                return 2;
+            }
+
+            const int defaultPort = 80; // matches WeatherLinkLiveFetcher.defaultPort
+
+            string host = args[0];
+            int port = defaultPort;
+            bool raw = false;
+            bool loop = false;
+            int intervalSeconds = 10;
+
+            for (int i = 1; i < args.Length; i++)
+            {
+                if (args[i] == "--raw")
+                    raw = true;
+                else if (args[i] == "--loop")
+                    loop = true;
+                else if (args[i] == "--interval" && i + 1 < args.Length)
+                    intervalSeconds = int.Parse(args[++i]);
+                else if (int.TryParse(args[i], out int p))
+                    port = p;
+            }
+
+            int exitCode = 0;
+            do
+            {
+                exitCode = RunOnce(host, port, raw);
+                if (loop)
+                {
+                    Console.WriteLine(new string('-', 60));
+                    Thread.Sleep(intervalSeconds * 1000);
+                }
+            } while (loop);
+
+            return exitCode;
+        }
+
+        static int RunOnce(string host, int port, bool raw)
+        {
+            string url = $"http://{host}:{port}/v1/current_conditions";
+            Console.WriteLine($"GET {url}");
+
+            string json = WeatherLinkLiveParser.FetchJson(host, port, 5000, out string error);
+            if (json == null)
+            {
+                Console.WriteLine($"FAIL  request failed: {error}");
+                return 1;
+            }
+
+            if (raw)
+            {
+                Console.WriteLine("--- raw response body ---");
+                Console.WriteLine(json);
+                Console.WriteLine("--------------------------");
+            }
+
+            WeatherLinkLiveConditions cond = WeatherLinkLiveParser.Parse(json, out error);
+            if (cond == null)
+            {
+                Console.WriteLine($"FAIL  parse failed: {error}");
+                Console.WriteLine("      (this is exactly why the driver would show every property as N/A --");
+                Console.WriteLine("       FetchSensorData() bails out here without touching sensorData at all)");
+                return 1;
+            }
+
+            Console.WriteLine("OK    parsed current conditions:");
+            Console.WriteLine($"        StationId       = {cond.StationId}");
+            PrintField("TempC", cond.TempC, "C");
+            PrintField("HumidityPct", cond.HumidityPct, "%");
+            PrintField("DewPointC", cond.DewPointC, "C");
+            PrintField("WindSpeedMps", cond.WindSpeedMps, "m/s");
+            PrintField("WindDirDeg", cond.WindDirDeg, "deg");
+            PrintField("WindGustMps", cond.WindGustMps, "m/s");
+            PrintField("RainRateInPerHr", cond.RainRateInPerHr, "in/hr");
+            PrintField("BarometerHPa", cond.BarometerHPa, "hPa");
+
+            int missing = 0;
+            missing += cond.TempC.HasValue ? 0 : 1;
+            missing += cond.HumidityPct.HasValue ? 0 : 1;
+            missing += cond.DewPointC.HasValue ? 0 : 1;
+            missing += cond.WindSpeedMps.HasValue ? 0 : 1;
+            missing += cond.WindGustMps.HasValue ? 0 : 1;
+            missing += cond.RainRateInPerHr.HasValue ? 0 : 1;
+            missing += cond.BarometerHPa.HasValue ? 0 : 1;
+            if (missing > 0)
+                Console.WriteLine($"WARN  {missing} field(s) came back null -- those specific ASCOM properties would show N/A even though the fetch/parse itself succeeded");
+
+            return 0;
+        }
+
+        static void PrintField(string name, double? value, string unit)
+        {
+            string shown = value.HasValue ? $"{value.Value} {unit}" : "(null -- missing/null in source JSON)";
+            Console.WriteLine($"        {name,-16}= {shown}");
+        }
+    }
+}

--- a/wll-cli/wll-cli.csproj
+++ b/wll-cli/wll-cli.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Standalone command-line harness for WeatherLinkLiveParser, the same
+    fetch/parse/unit-conversion code the real driver uses for the JSON
+    protocol (VantagePro.IPProtocolMode.Json), with zero dependency on
+    ASCOM.Utilities (Profile/Util/TraceLogger all need Microsoft.VisualBasic
+    at runtime, which Debian's Mono package doesn't ship). That means this
+    project builds and runs anywhere .NET Framework 4.7.2 code can run,
+    including under plain Mono on Linux with no ASCOM Platform installed,
+    so you can point it straight at a real WeatherLink Live hub (or rtldavis's
+    emulation of one) and see exactly what the driver would parse out of its
+    response, independent of MaximDL/TheSkyX/COM registration entirely.
+
+    Build (from this directory):
+      dotnet build -f net472 /p:FrameworkPathOverride=(path to net472 reference assemblies)
+    Run:
+      mono bin/Debug/net472/wll-cli.exe host [port] [raw flag] [loop flag] [interval flag, seconds]
+      (run with no arguments to see the exact flag names)
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>wll-cli</AssemblyName>
+    <RootNamespace>ASCOM.VantagePro.WllCli</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../WeatherLinkLiveParser.cs" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>../packages/Newtonsoft.Json.12.0.2/lib/net45/Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- The driver could previously only speak the legacy binary WeatherLinkIP protocol (wakeup/WRD/LOOP over a raw socket, port 22222). That's a different product line from the WeatherLink Live hub, which serves current conditions as JSON over plain HTTP (`GET /v1/current_conditions`, port 80) and never listens on 22222 at all — confirmed by hand against both a real WeatherLink Live hub and rtldavis's emulation of one.
- Adds a protocol choice under the existing "IP" operational mode (`VantagePro.IPProtocol`: Serial or Json) rather than a new top-level mode, since it's the same host:port, just a different wire format. A new `WeatherLinkLiveFetcher` parses the JSON response (`data_structure_type` 1 for temp/humidity/wind/rain, 3 for barometer) into the same `sensorData` dictionary keys the existing `Fetcher` properties already read, so nothing downstream needed to change. The setup dialog grows a "Protocol" row (Legacy 22222 / WeatherLink Live JSON 80) that's only enabled in IP mode, with a small UX touch of swapping the displayed port to the new protocol's default when you flip between them.
- The JSON fetch/parse/unit-conversion logic is split out into a standalone `WeatherLinkLiveParser` with zero `ASCOM.Utilities` dependency (Profile/Util/TraceLogger all need `Microsoft.VisualBasic` at runtime, which Debian's Mono package doesn't ship, so nothing touching `ASCOM.Utilities` can run under Mono). A small `wll-cli` diagnostic harness links the parser directly and builds/runs under plain Mono on Linux, for pointing at a real hub or an emulation of one without needing the ASCOM Platform, COM, or a Windows box.
- Also fixes two real bugs found along the way, both confirmed against trace logs from a live MaximDL session:
  - `ObservingConditions.Dispose()` was disposing and nulling `tl`, an alias for the process-wide `VantagePro.tl` singleton shared by every `Fetcher` and every `ObservingConditions` COM wrapper instance — the first dispose silently killed tracing for the rest of the process.
  - `Connected = true` returned before the first async fetch completed, so clients (MaximDL observed reading properties within 1-8ms of `Connected` returning) hit the still-empty `sensorData` dictionary and got `PropertyNotImplementedException` (shown as N/A) on every property, even though the fetch itself worked fine moments later. `Start()` now performs one synchronous fetch before scheduling the recurring async timer.

Opening as a draft since it's a larger feature addition — happy to split commits differently or adjust the UI approach if you'd prefer something other than a protocol radio button under IP mode.

## Test plan
- [x] `wll-cli` verified against a real WeatherLink Live hub: all 8 fields parse correctly
- [x] Verified against MaximDL trace logs (`Connected`/property-read race, tracing lifecycle)
- [ ] Maintainer review of the setup-dialog UX and the `VantagePro.IPProtocol` modeling choice