### PR TITLE
fix: stop nulling fetcher fields on OK, surface real exceptions from Test

### DIFF
--- a/SetupDialogForm.cs
+++ b/SetupDialogForm.cs
@@ -73,10 +73,13 @@ namespace ASCOM.VantagePro
             socketFetcher.WriteLowerProfile();
             serialPortFetcher.WriteLowerProfile();
 
-            serialPortFetcher = null;
-            socketFetcher = null;
-            fileFetcher = null;
-            vantagePro = null;
+            // Not nulling serialPortFetcher/socketFetcher/fileFetcher/vantagePro here
+            // deliberately: cmdOK is a DialogResult button, so clicking it normally
+            // closes this ShowDialog()'d form right after this handler returns -- but
+            // if that doesn't happen (or the dialog otherwise stays open), a
+            // subsequent "Test configuration" click on now-null fetcher fields threw
+            // an unguarded NullReferenceException. The form's own Dispose() cleans
+            // these up regardless; there's no benefit to nulling them early.
         }
 
         private void cmdCancel_Click(object sender, EventArgs e) // Cancel button event handler
@@ -210,17 +213,29 @@ namespace ASCOM.VantagePro
 
             VantagePro.tl.Enabled = chkTrace.Checked;
             buttonTest.Text = "Testing ...";
-            if (radioButtonReportFile.Checked)
+            try
             {
-                fileFetcher.Test(textBoxReportFile.Text, ref result, ref resultColor);
+                if (radioButtonReportFile.Checked)
+                {
+                    fileFetcher.Test(textBoxReportFile.Text, ref result, ref resultColor);
+                }
+                else if (radioButtonSerialPort.Checked)
+                {
+                    serialPortFetcher.Test(comboBoxComPort.Text, ref result, ref resultColor);
+                }
+                else if (radioButtonIP.Checked)
+                {
+                    socketFetcher.Test(textBoxIPAddress.Text, textBoxIPPort.Text, ref result, ref resultColor);
+                }
             }
-            else if (radioButtonSerialPort.Checked)
+            catch (Exception ex)
             {
-                serialPortFetcher.Test(comboBoxComPort.Text, ref result, ref resultColor);
-            }
-            else if (radioButtonIP.Checked)
-            {
-                socketFetcher.Test(textBoxIPAddress.Text, textBoxIPPort.Text, ref result, ref resultColor);
+                // Surface the real exception instead of letting it escape to the
+                // unhandled-exception dialog, which collapses the stack down to
+                // just this handler and hides which fetcher/field was actually null.
+                result = $"{ex.GetType().Name}: {ex.Message}\n\n{ex.StackTrace}";
+                resultColor = VantagePro.colorError;
+                VantagePro.LogMessage("buttonTest_Click", $"Test threw: {result}");
             }
 
             if (resultColor == VantagePro.colorGood)


### PR DESCRIPTION
## Summary
- `cmdOK_Click` nulled `serialPortFetcher`/`socketFetcher`/`fileFetcher`/`vantagePro` after writing the profile, on the assumption the `DialogResult`-bound OK button always closes the `ShowDialog()`'d form immediately after. If that doesn't happen, a later "Test configuration" click null-derefs one of those fields with no benefit ever having nulled them (the form's own `Dispose()` cleans them up regardless).
- Also wraps `buttonTest_Click`'s dispatch to `fileFetcher`/`serialPortFetcher`/`socketFetcher.Test()` in a try/catch that shows the real exception type, message, and stack trace instead of letting it hit the unhandled-exception dialog — that dialog collapses the stack down to just `buttonTest_Click` (`Test()`/`StationModel`/`Open()`/`Wakeup()` all contain their own try/catch, so the JIT won't inline them as callees), which hides which field or call actually failed.

This is a standalone bugfix unrelated to our other two PRs (CI workflow, WeatherLink Live JSON support) — splitting it out separately so it can be reviewed/merged independently.

## Test plan
- [ ] Maintainer review — no automated coverage for the setup dialog's WinForms event handlers